### PR TITLE
Create validate-credentials endpoint stubs

### DIFF
--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace MyParcelCom\Microservice\Credentials;
 
 use Illuminate\Http\JsonResponse;
+use MyParcelCom\JsonApi\Exceptions\InvalidJsonSchemaException;
 use MyParcelCom\Microservice\Carrier\CarrierApiGatewayInterface;
 use MyParcelCom\Microservice\Http\Controllers\Controller;
+use MyParcelCom\Microservice\Http\JsonRequestValidator;
 use MyParcelCom\Microservice\Http\Request;
 
 class CredentialController extends Controller
@@ -27,18 +29,28 @@ class CredentialController extends Controller
     /**
      * Validates the given credentials
      *
-     * @param Request $request
+     * @param JsonRequestValidator $jsonRequestValidator
+     * @param Request              $request
      * @return JsonResponse
      */
-    public function validateCredentials(Request $request)
-    {
-        $valid = true;
+    public function validateCredentials(
+        JsonRequestValidator $jsonRequestValidator,
+        Request $request
+    ) {
+        try {
+            $jsonRequestValidator->validate('/validate-credentials', 'post', null);
+        } catch (InvalidJsonSchemaException $e) {
+            return $this->invalidResponse('Request body does not match schema');
+        }
+
         // TODO: implement validation check
         // Some carriers may have dedicated endpoints
         // for this. Otherwise you could try a random
         // GET endpoint and see if it comes up with
         // any erroneous status codes related to
         // invalid credentials
+        $valid = true;
+
         if (!$valid) {
             return $this->invalidResponse('Credentials given are invalid');
         }

--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -28,7 +28,8 @@ class CredentialController extends Controller
      *
      * @return JsonResponse
      */
-    public function validateCredentials() {
+    public function validateCredentials(): JsonResponse
+    {
 
         // TODO: implement validation check
         // Some carriers may have dedicated endpoints
@@ -54,7 +55,7 @@ class CredentialController extends Controller
      * @param int    $statusCode
      * @return JsonResponse
      */
-    protected function invalidResponse(string $message = '', $statusCode = JsonResponse::HTTP_BAD_REQUEST)
+    protected function invalidResponse(string $message = '', $statusCode = JsonResponse::HTTP_BAD_REQUEST): JsonResponse
     {
         return new JsonResponse([
             'data' => [

--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace MyParcelCom\Microservice\Credentials;
 
 use Illuminate\Http\JsonResponse;
-use MyParcelCom\JsonApi\Exceptions\InvalidJsonSchemaException;
 use MyParcelCom\Microservice\Carrier\CarrierApiGatewayInterface;
 use MyParcelCom\Microservice\Http\Controllers\Controller;
-use MyParcelCom\Microservice\Http\JsonRequestValidator;
-use MyParcelCom\Microservice\Http\Request;
 
 class CredentialController extends Controller
 {

--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -27,21 +27,11 @@ class CredentialController extends Controller
     }
 
     /**
-     * Validates the given credentials
+     * Validates credentials in the header
      *
-     * @param JsonRequestValidator $jsonRequestValidator
-     * @param Request              $request
      * @return JsonResponse
      */
-    public function validateCredentials(
-        JsonRequestValidator $jsonRequestValidator,
-        Request $request
-    ) {
-        try {
-            $jsonRequestValidator->validate('/validate-credentials', 'post', null);
-        } catch (InvalidJsonSchemaException $e) {
-            return $this->invalidResponse('Request body does not match schema');
-        }
+    public function validateCredentials() {
 
         // TODO: implement validation check
         // Some carriers may have dedicated endpoints

--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -42,10 +42,11 @@ class CredentialController extends Controller
             return $this->invalidResponse('Credentials given are invalid');
         }
 
-        return new JsonResponse(
-            ['valid' => true],
-            JsonResponse::HTTP_OK
-        );
+        return new JsonResponse([
+            'data' => [
+                'valid' => true,
+            ],
+        ], JsonResponse::HTTP_OK);
     }
 
     /**
@@ -55,12 +56,11 @@ class CredentialController extends Controller
      */
     protected function invalidResponse(string $message = '', $statusCode = JsonResponse::HTTP_BAD_REQUEST)
     {
-        return new JsonResponse(
-            [
+        return new JsonResponse([
+            'data' => [
                 'valid' => false,
-                'message' => $message
+                'message' => $message,
             ],
-            $statusCode
-        );
+        ], $statusCode);
     }
 }

--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Microservice\Credentials;
+
+use Illuminate\Http\JsonResponse;
+use MyParcelCom\Microservice\Carrier\CarrierApiGatewayInterface;
+use MyParcelCom\Microservice\Http\Controllers\Controller;
+use MyParcelCom\Microservice\Http\Request;
+
+class CredentialController extends Controller
+{
+    /**
+     * @var CarrierApiGatewayInterface
+     */
+    protected $carrierApiGateway;
+
+    /**
+     * @param CarrierApiGatewayInterface $carrierApiGateway
+     */
+    public function __construct(CarrierApiGatewayInterface $carrierApiGateway)
+    {
+        $this->carrierApiGateway = $carrierApiGateway;
+    }
+
+    /**
+     * Validates the given credentials
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function validate(Request $request)
+    {
+        $valid = true;
+        // TODO: implement validation check
+        // Some carriers may have dedicated endpoints
+        // for this. Otherwise you could try a random
+        // GET endpoint and see if it comes up with
+        // any erroneous status codes related to
+        // invalid credentials
+        if (!$valid) {
+            return $this->invalidResponse('Credentials given are invalid');
+        }
+
+        return new JsonResponse(
+            ['valid' => true],
+            JsonResponse::HTTP_OK
+        );
+    }
+
+    /**
+     * @param string $message
+     * @param int    $statusCode
+     * @return JsonResponse
+     */
+    protected function invalidResponse(string $message = '', $statusCode = JsonResponse::HTTP_BAD_REQUEST)
+    {
+        return new JsonResponse(
+            [
+                'valid' => false,
+                'message' => $message
+            ],
+            $statusCode
+        );
+    }
+}

--- a/app/Credentials/CredentialController.php
+++ b/app/Credentials/CredentialController.php
@@ -30,7 +30,7 @@ class CredentialController extends Controller
      * @param Request $request
      * @return JsonResponse
      */
-    public function validate(Request $request)
+    public function validateCredentials(Request $request)
     {
         $valid = true;
         // TODO: implement validation check

--- a/app/Http/JsonRequestValidator.php
+++ b/app/Http/JsonRequestValidator.php
@@ -24,14 +24,21 @@ class JsonRequestValidator
      *
      * @param string      $schemaPath
      * @param string|null $method
-     * @param int         $status
+     * @param null|int    $status
      * @throws InvalidJsonSchemaException
      */
-    public function validate(string $schemaPath, string $method = null, int $status = 200): void
+    public function validate(string $schemaPath, string $method = null, ?int $status = 200): void
     {
         $method = $method ?? strtolower($this->request->getRealMethod());
 
-        $schema = $this->schema->paths->{$schemaPath}->{$method}->responses->{$status}->schema;
+        if ($status !== null) {
+            $schema = $this->schema->paths->{$schemaPath}->{$method}->responses->{$status}->schema;
+        } else {
+            $parameters = $this->schema->paths->{$schemaPath}->{$method}->parameters;
+
+            $schema = $parameters[array_search('body', array_column($parameters, 'in'))]->schema;
+        }
+
 
         $postData = json_decode($this->request->getContent());
 

--- a/app/Shipments/ShipmentController.php
+++ b/app/Shipments/ShipmentController.php
@@ -26,8 +26,13 @@ class ShipmentController extends Controller
      * @throws InvalidJsonSchemaException
      * @throws \MyParcelCom\JsonApi\Transformers\TransformerException
      */
-    public function create(JsonRequestValidator $jsonRequestValidator, ApiRequestValidator $apiRequestValidator, ShipmentRepository $repository, Request $request, TransformerService $transformerService): JsonResponse
-    {
+    public function create(
+        JsonRequestValidator $jsonRequestValidator,
+        ApiRequestValidator $apiRequestValidator,
+        ShipmentRepository $repository,
+        Request $request,
+        TransformerService $transformerService
+    ): JsonResponse {
         $jsonRequestValidator->validate('/shipments', 'post', 201);
 
         // TODO Add rules to ApiRequestValidator to include carrier-specific requirements.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "justinrainbow/json-schema": "^5.2",
     "laravel/framework": "5.5.*",
     "laravel/tinker": "~1.0",
-    "myparcelcom/carrier-specification": "^0.3.0",
+    "myparcelcom/carrier-specification": "^0.3.2",
     "myparcelcom/json-api": "^0.5.0",
     "predis/predis": "~1.0",
     "tecnickcom/tc-lib-barcode": "^1.15",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afb888d73216092dcdc25316fd5d099b",
+    "content-hash": "020b7686d490e5a0bf7623eb7871a346",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1144,23 +1144,23 @@
         },
         {
             "name": "myparcelcom/carrier-specification",
-            "version": "v0.3.0",
+            "version": "v0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MyParcelCOM/carrier-specification.git",
-                "reference": "4ee23d150528baf971132a7f2e537c0a06fe7544"
+                "reference": "e8566a8caf83d403bb47e67f88c3a71eaa830992"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MyParcelCOM/carrier-specification/zipball/4ee23d150528baf971132a7f2e537c0a06fe7544",
-                "reference": "4ee23d150528baf971132a7f2e537c0a06fe7544",
+                "url": "https://api.github.com/repos/MyParcelCOM/carrier-specification/zipball/e8566a8caf83d403bb47e67f88c3a71eaa830992",
+                "reference": "e8566a8caf83d403bb47e67f88c3a71eaa830992",
                 "shasum": ""
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "description": "MyParcel.com carrier API specification.",
             "homepage": "https://docs.myparcel.com/carrier-specification",
-            "time": "2018-03-07T09:27:42+00:00"
+            "time": "2018-06-11T09:43:04+00:00"
         },
         {
             "name": "myparcelcom/json-api",

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,4 +26,4 @@ Route::get(
 Route::get('/v1/shipments/{shipmentId}/statuses/{trackingCode}', StatusController::class . '@getStatuses');
 Route::post('/v1/shipments', ShipmentController::class . '@create');
 
-Route::post('/v1/validate-credentials', CredentialController::class . '@validate');
+Route::post('/v1/validate-credentials', CredentialController::class . '@validateCredentials');

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,4 +26,4 @@ Route::get(
 Route::get('/v1/shipments/{shipmentId}/statuses/{trackingCode}', StatusController::class . '@getStatuses');
 Route::post('/v1/shipments', ShipmentController::class . '@create');
 
-Route::post('/v1/validate-credentials', CredentialController::class . '@validateCredentials');
+Route::get('/v1/validate-credentials', CredentialController::class . '@validateCredentials');

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
+use MyParcelCom\Microservice\Credentials\CredentialController;
 use MyParcelCom\Microservice\PickUpDropOffLocations\PickUpDropOffLocationController;
 use MyParcelCom\Microservice\Shipments\ShipmentController;
 use MyParcelCom\Microservice\Statuses\StatusController;
@@ -24,3 +25,5 @@ Route::get(
 
 Route::get('/v1/shipments/{shipmentId}/statuses/{trackingCode}', StatusController::class . '@getStatuses');
 Route::post('/v1/shipments', ShipmentController::class . '@create');
+
+Route::post('/v1/validate-credentials', CredentialController::class . '@validate');

--- a/tests/Endpoints/ValidateCredentialsTest.php
+++ b/tests/Endpoints/ValidateCredentialsTest.php
@@ -48,9 +48,6 @@ class ValidateCredentialsTest extends TestCase
             'get',
             200
         );
-
-        $response = $this->json('GET', '/v1/validate-credentials', [], $this->getRequestHeaders());
-        $response->assertStatus(200);
     }
 
 }

--- a/tests/Endpoints/ValidateCredentialsTest.php
+++ b/tests/Endpoints/ValidateCredentialsTest.php
@@ -20,13 +20,10 @@ class ValidateCredentialsTest extends TestCase
     {
         $this->bindCarrierApiGatewayMock();
 
-        $data = [
-            'credentials' => [
-                'foo' => 'bar'
-            ]
-        ];
-
-        $response = $this->json('POST', '/v1/validate-credentials', $data, $this->getRequestHeaders());
+        $response = $this->json('GET', '/v1/validate-credentials', [], [
+            'foo' => 'bar',
+            'some' => 'credentials'
+        ]);
         $response->assertStatus(400);
     }
 
@@ -35,11 +32,7 @@ class ValidateCredentialsTest extends TestCase
     {
         $this->bindCarrierApiGatewayMock();
 
-        $data = [
-            'credentials' => config('services.carrier_credentials')
-        ];
-
-        $response = $this->json('POST', '/v1/validate-credentials', $data, $this->getRequestHeaders());
+        $response = $this->json('GET', '/v1/validate-credentials', [], $this->getRequestHeaders());
         $response->assertStatus(200);
     }
 

--- a/tests/Endpoints/ValidateCredentialsTest.php
+++ b/tests/Endpoints/ValidateCredentialsTest.php
@@ -7,6 +7,10 @@ namespace MyParcelCom\Microservice\Tests\Endpoints;
 use MyParcelCom\Microservice\Tests\TestCase;
 use MyParcelCom\Microservice\Tests\Traits\CommunicatesWithCarrier;
 
+/**
+ * @group Endpoints:Shipment
+ * @group Implementation
+ */
 class ValidateCredentialsTest extends TestCase
 {
     use CommunicatesWithCarrier;
@@ -22,7 +26,7 @@ class ValidateCredentialsTest extends TestCase
             ]
         ];
 
-        $response = $this->json('POST', '/validate-credentials', $data);
+        $response = $this->json('POST', '/v1/validate-credentials', $data, $this->getRequestHeaders());
         $response->assertStatus(400);
     }
 
@@ -35,7 +39,7 @@ class ValidateCredentialsTest extends TestCase
             'credentials' => config('services.carrier_credentials')
         ];
 
-        $response = $this->json('POST', '/validate-credentials', $data);
+        $response = $this->json('POST', '/v1/validate-credentials', $data, $this->getRequestHeaders());
         $response->assertStatus(200);
     }
 

--- a/tests/Endpoints/ValidateCredentialsTest.php
+++ b/tests/Endpoints/ValidateCredentialsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Microservice\Tests\Endpoints;
+
+use MyParcelCom\Microservice\Tests\TestCase;
+use MyParcelCom\Microservice\Tests\Traits\CommunicatesWithCarrier;
+
+class ValidateCredentialsTest extends TestCase
+{
+    use CommunicatesWithCarrier;
+
+    /** @test */
+    public function testItReturnsAnUnsuccessfulResponseWithInvalidCredentials()
+    {
+        $this->bindCarrierApiGatewayMock();
+
+        $data = [
+            'credentials' => [
+                'foo' => 'bar'
+            ]
+        ];
+
+        $response = $this->json('POST', '/validate-credentials', $data);
+        $response->assertStatus(400);
+    }
+
+    /** @test */
+    public function testItReturnsASuccessfulResponseWithValidCredentials()
+    {
+        $this->bindCarrierApiGatewayMock();
+
+        $data = [
+            'credentials' => config('services.carrier_credentials')
+        ];
+
+        $response = $this->json('POST', '/validate-credentials', $data);
+        $response->assertStatus(200);
+    }
+
+}

--- a/tests/Endpoints/ValidateCredentialsTest.php
+++ b/tests/Endpoints/ValidateCredentialsTest.php
@@ -6,6 +6,7 @@ namespace MyParcelCom\Microservice\Tests\Endpoints;
 
 use MyParcelCom\Microservice\Tests\TestCase;
 use MyParcelCom\Microservice\Tests\Traits\CommunicatesWithCarrier;
+use MyParcelCom\Microservice\Tests\Traits\JsonApiAssertionsTrait;
 
 /**
  * @group Endpoints:Shipment
@@ -14,23 +15,39 @@ use MyParcelCom\Microservice\Tests\Traits\CommunicatesWithCarrier;
 class ValidateCredentialsTest extends TestCase
 {
     use CommunicatesWithCarrier;
+    use JsonApiAssertionsTrait;
 
     /** @test */
     public function testItReturnsAnUnsuccessfulResponseWithInvalidCredentials()
     {
         $this->bindCarrierApiGatewayMock();
 
-        $response = $this->json('GET', '/v1/validate-credentials', [], [
-            'foo' => 'bar',
-            'some' => 'credentials'
-        ]);
-        $response->assertStatus(400);
+        $this->assertJsonSchema(
+            '/validate-credentials',
+            '/v1/validate-credentials',
+            [
+                'foo' => 'bar',
+                'some' => 'credentials'
+            ],
+            [],
+            'get',
+            400
+        );
     }
 
     /** @test */
     public function testItReturnsASuccessfulResponseWithValidCredentials()
     {
         $this->bindCarrierApiGatewayMock();
+
+        $this->assertJsonSchema(
+            '/validate-credentials',
+            '/v1/validate-credentials',
+            $this->getRequestHeaders(),
+            [],
+            'get',
+            200
+        );
 
         $response = $this->json('GET', '/v1/validate-credentials', [], $this->getRequestHeaders());
         $response->assertStatus(200);


### PR DESCRIPTION
**Changes**
- Added `validate-credentials` endpoint
- Made `$status` nullable on `JsonRequestValidator::validate()`

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-900
- https://myparcelcombv.atlassian.net/browse/MP-898