### PR TITLE
Fixed ShipmentItem::getSku() not being able to return null.

### DIFF
--- a/app/Shipments/ShipmentItem.php
+++ b/app/Shipments/ShipmentItem.php
@@ -35,9 +35,9 @@ class ShipmentItem
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSku(): string
+    public function getSku(): ?string
     {
         return $this->sku;
     }

--- a/tests/Unit/Shipments/ShipmentItemTest.php
+++ b/tests/Unit/Shipments/ShipmentItemTest.php
@@ -55,6 +55,9 @@ class ShipmentItemTest extends TestCase
     public function testSku()
     {
         $item = new ShipmentItem();
+
+        $this->assertNull($item->getSku());
+
         $this->assertEquals('DVC-2314/12', $item->setSku('DVC-2314/12')->getSku());
     }
 }


### PR DESCRIPTION
When SKU is not set, the microservice throws an error when retrieving sku because it returns `null`, which is not a `string`.