### PR TITLE
:recycle: make non required properties nullable

### DIFF
--- a/app/Shipments/ShipmentItem.php
+++ b/app/Shipments/ShipmentItem.php
@@ -8,18 +8,25 @@ class ShipmentItem
 {
     /** @var string */
     protected $sku;
+
     /** @var string */
     protected $description;
+
     /** @var string */
     protected $hsCode;
+
     /** @var int */
     protected $quantity;
+
     /** @var int */
     protected $itemValueAmount;
+
     /** @var string */
     protected $itemValueCurrency;
+
     /** @var string */
     protected $originCountryCode;
+
     /** @var int */
     protected $itemWeight;
 
@@ -73,9 +80,9 @@ class ShipmentItem
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getHsCode(): string
+    public function getHsCode(): ?string
     {
         return $this->hsCode;
     }
@@ -149,17 +156,17 @@ class ShipmentItem
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getOriginCountryCode(): string
+    public function getOriginCountryCode(): ?string
     {
         return $this->originCountryCode;
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getItemWeight(): int
+    public function getItemWeight(): ?int
     {
         return $this->itemWeight;
     }

--- a/tests/Unit/Shipments/ShipmentItemTest.php
+++ b/tests/Unit/Shipments/ShipmentItemTest.php
@@ -20,6 +20,7 @@ class ShipmentItemTest extends TestCase
     public function testHsCode()
     {
         $item = new ShipmentItem();
+        $this->assertNull($item->getHsCode());
         $this->assertEquals('3215.32.54', $item->setHsCode('3215.32.54')->getHsCode());
     }
 
@@ -41,6 +42,7 @@ class ShipmentItemTest extends TestCase
     public function testOriginCountryCode()
     {
         $item = new ShipmentItem();
+        $this->assertNull($item->getOriginCountryCode());
         $this->assertEquals('CN', $item->setOriginCountryCode('CN')->getOriginCountryCode());
     }
 
@@ -55,9 +57,15 @@ class ShipmentItemTest extends TestCase
     public function testSku()
     {
         $item = new ShipmentItem();
-
         $this->assertNull($item->getSku());
-
         $this->assertEquals('DVC-2314/12', $item->setSku('DVC-2314/12')->getSku());
+    }
+
+    /** @test */
+    public function testItemWeight()
+    {
+        $item = new ShipmentItem();
+        $this->assertNull($item->getItemWeight());
+        $this->assertEquals(37, $item->setItemWeight(37)->getItemWeight());
     }
 }


### PR DESCRIPTION
https://docs.myparcel.com/carrier-specification/#/Shipments/post_shipments
According to the carrier-specification some shipment item fields are not required.
These getters should be able to return null values.