### PR TITLE
Disabled code coverage on tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,11 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ./mp.sh test --no-coverage
+            if [ "${CIRCLE_PROJECT_REPONAME##*-}" != "skeleton" ]; then
+              ./mp.sh test --no-coverage
+            else
+              ./mp.sh test skeleton
+            fi
             if [ "$(head -n 3 build/report.junit.xml | grep 'errors="0"' | grep 'failures="0"')" == '' ]; then exit 1; else exit 0; fi
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            ./mp.sh test skeleton
+            ./mp.sh test --no-coverage
             if [ "$(head -n 3 build/report.junit.xml | grep 'errors="0"' | grep 'failures="0"')" == '' ]; then exit 1; else exit 0; fi
 
   build:


### PR DESCRIPTION
Microservices do not run tests with coverage so it makes sense to disable it in the skeleton too.