### PR TITLE
Removing coverage check in test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             if [ "${CIRCLE_PROJECT_REPONAME##*-}" != "skeleton" ]; then
               ./mp.sh test --no-coverage
             else
-              ./mp.sh test skeleton
+              ./mp.sh test skeleton --no-coverage
             fi
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
             else
               ./mp.sh test skeleton
             fi
-            if [ "$(head -n 3 build/report.junit.xml | grep 'errors="0"' | grep 'failures="0"')" == '' ]; then exit 1; else exit 0; fi
 
   build:
     machine:


### PR DESCRIPTION
Since we disabled the coverage generation from the tests we can remove the check for the generated file too.