### PR TITLE
🐛 Fixed a bug where strlen could be called on non-strings.

### DIFF
--- a/app/Rules/CombinedFieldsMaxRule.php
+++ b/app/Rules/CombinedFieldsMaxRule.php
@@ -20,7 +20,7 @@ class CombinedFieldsMaxRule implements CustomRuleInterface
         $requestBody = $validator->getData();
 
         $otherParams = array_map(function ($param) use ($requestBody) {
-            return Arr::get($requestBody, $param);
+            return (string) Arr::get($requestBody, $param);
         }, $parameters);
 
         // Filter out empty strings.

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -194,6 +194,8 @@ return [
         'data.attributes.items.*.sku'                 => 'shipment item sku code',
         'data.attributes.items.*.description'         => 'shipment item description',
         'data.attributes.items.*.item_value'          => 'shipment item value',
+        'data.attributes.items.*.item_value.amount'   => 'shipment item value amount',
+        'data.attributes.items.*.item_value.currency' => 'shipment item value currency',
         'data.attributes.items.*.item_weight'         => 'shipment item weight',
         'data.attributes.items.*.quantity'            => 'shipment item quantity',
         'data.attributes.items.*.hs_code'             => 'shipment item hs code',


### PR DESCRIPTION
**Changes**
- Added cast to string for all parameters given to the combined_fields_max rule except the first one (which is always supposed to be an int).

**Notes**
- This was causing issues in the DPD microservice.