### PR TITLE
♻️ Save extracted street_2 data when splitting street_1

### DIFF
--- a/app/PickUpDropOffLocations/Address.php
+++ b/app/PickUpDropOffLocations/Address.php
@@ -69,9 +69,11 @@ class Address
         if ($street1 && $combined) {
             try {
                 $addressBreakdown = AddressSplitter::splitAddress($street1);
-                $street1 = $addressBreakdown['streetName'];
-                $this->setStreetNumber((int) Arr::get($addressBreakdown, 'houseNumberParts.base'));
+                $street1 = Arr::get($addressBreakdown, 'streetName');
+                $number = Arr::get($addressBreakdown, 'houseNumberParts.base');
+                $this->setStreetNumber(empty($number) ? null : (int) $number);
                 $this->setStreetNumberSuffix(Arr::get($addressBreakdown, 'houseNumberParts.extension'));
+                $this->setStreet2(Arr::get($addressBreakdown, 'additionToAddress2'));
             } catch (SplittingException $e) {
                 // cannot split address, ignore
             }


### PR DESCRIPTION
The address splitter puts leftover data from `street_1` into `additionToAddress2` which is ignored in our implementation so far.
We should respect this extracted data and put it in our `street_2`.

Note: this leftover data in `street_2` will be overwritten if the provided shipment has `street_2` as well, but I think that's fine.