### PR TITLE
Fix / ShipmentMapper setConsolidationShipments

### DIFF
--- a/app/Shipments/ShipmentMapper.php
+++ b/app/Shipments/ShipmentMapper.php
@@ -125,7 +125,7 @@ class ShipmentMapper implements MapperInterface
         $relationships = Arr::get($data, 'relationships');
 
         if (isset($relationships['consolidated_shipments'])) {
-            $shipment->setConsolidationShipments(new Collection($relationships['consolidated_shipments']));
+            $shipment->setConsolidationShipments(new Collection($relationships['consolidated_shipments']['data']));
         }
 
         return $shipment;

--- a/app/Shipments/ShipmentTransformer.php
+++ b/app/Shipments/ShipmentTransformer.php
@@ -162,7 +162,7 @@ class ShipmentTransformer extends AbstractTransformer
      */
     public function getRelationships($shipment): array
     {
-        $shipmentIDs = $shipment->getConsolidationShipments()->map(fn (Shipment $shipment) => $shipment->getId())->all();
+        $shipmentIDs = $shipment->getConsolidationShipments()->map(fn (array $shipment) => $shipment['id'])->all();
 
         return array_filter([
             'consolidated_shipments' => $this->transformRelationshipForIdentifiers($shipmentIDs, 'shipments'),

--- a/tests/Unit/Shipments/ShipmentTransformerTest.php
+++ b/tests/Unit/Shipments/ShipmentTransformerTest.php
@@ -160,12 +160,12 @@ class ShipmentTransformerTest extends TestCase
                 'getTrackingCode' => 'TR4CK1NGC0D3',
             ]),
             'getConsolidationShipments'            => new Collection([
-                Mockery::mock(Shipment::class, [
-                    'getId' => 'con-1',
-                ]),
-                Mockery::mock(Shipment::class, [
-                    'getId' => 'con-2',
-                ]),
+                [
+                    'id' => 'con-1',
+                ],
+                [
+                    'id' => 'con-2',
+                ],
             ]),
         ]);
 


### PR DESCRIPTION
Consolidation shipments are nested under `relationships.consolidated_shipments.data` in the (example) request data for the [Create Shipment endpoint](https://carrier-specification.myparcel.com/#tag/Shipments/paths/~1shipments/post), but in the `ShipmentMapper` they were set on the Shipment as `relationships.consolidated_shipments` (thereby including the `data` key, which I believe is an accident).

In the `ShipmentTransformer`, the items in the Collection that is retrieved with `$shipment->getConsolidationShipments()` were type hinted as `Shipment` class, while they are in fact plain (associative) arrays.

This PR fixes both issues.