### PR TITLE
:sparkles: Added weight unit enum and weight converter helper.

### DIFF
--- a/app/Enums/WeightUnitEnum.php
+++ b/app/Enums/WeightUnitEnum.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Microservice\Enums;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static WeightUnitEnum MILLIGRAM()
+ * @method static WeightUnitEnum GRAM()
+ * @method static WeightUnitEnum KILOGRAM()
+ * @method static WeightUnitEnum OUNCE()
+ * @method static WeightUnitEnum POUND()
+ */
+class WeightUnitEnum extends Enum
+{
+    public const MILLIGRAM = 'mg';
+    public const GRAM = 'g';
+    public const KILOGRAM = 'kg';
+    public const OUNCE = 'oz';
+    public const POUND = 'lb';
+}

--- a/app/Helpers/WeightConverter.php
+++ b/app/Helpers/WeightConverter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Microservice\Helpers;
+
+use MyParcelCom\Microservice\Enums\WeightUnitEnum;
+
+class WeightConverter
+{
+    public static function convert(int|float $weight, string $from, ?string $to = 'g'): int|float
+    {
+        $weightInGrams = self::convertToGrams($weight, $from);
+
+        return self::convertFromGrams($weightInGrams, $to);
+    }
+
+    private static function convertToGrams(int|float $weight, string $from): int|float
+    {
+        return match ($from) {
+            WeightUnitEnum::MILLIGRAM => $weight / 1000,
+            WeightUnitEnum::GRAM => $weight,
+            WeightUnitEnum::KILOGRAM => $weight * 1000,
+            WeightUnitEnum::OUNCE => $weight * 28.3495,
+            WeightUnitEnum::POUND => $weight * 453.592,
+            default => throw new \InvalidArgumentException('Invalid weight unit'),
+        };
+    }
+
+    private static function convertFromGrams(float|int $weightInGrams, string $to): float|int
+    {
+        return match ($to) {
+            WeightUnitEnum::MILLIGRAM => $weightInGrams * 1000,
+            WeightUnitEnum::GRAM => $weightInGrams,
+            WeightUnitEnum::KILOGRAM => $weightInGrams / 1000,
+            WeightUnitEnum::OUNCE => $weightInGrams / 28.3495,
+            WeightUnitEnum::POUND => $weightInGrams / 453.592,
+            default => throw new \InvalidArgumentException('Invalid weight unit'),
+        };
+    }
+}


### PR DESCRIPTION
In order to convert the weight units, we can reuse the helper class from the API and while we're at it we should introduce the enum as well.

## Changes
- Added WeightUnitEnum 
- Added WeightConverter helper class.