### PR TITLE
🚑 Fix weight unit access before initialization

### DIFF
--- a/app/Shipments/ShipmentItem.php
+++ b/app/Shipments/ShipmentItem.php
@@ -33,7 +33,7 @@ class ShipmentItem
     /** @var int|null */
     protected $itemWeight;
 
-    protected ?string $itemWeightUnit;
+    protected ?string $itemWeightUnit = null;
 
     /** @var int|null */
     protected $taxAmount;


### PR DESCRIPTION
## Changes
- Gave the `$itemWeightUnit` property of ShipmentItems a default value of `null`.