### PR TITLE
🐛 Always save updated collection

### DIFF
--- a/app/Collections/CollectionRepository.php
+++ b/app/Collections/CollectionRepository.php
@@ -61,9 +61,9 @@ class CollectionRepository
             // TODO: If applicable, map tracking code and files to the Collection resource.
 
             $updatedCollection->setRegisteredAt(Carbon::now());
-
-            $updatedCollection->save();
         }
+
+        $updatedCollection->save();
 
         return $updatedCollection;
     }


### PR DESCRIPTION
Before, collections were only updated when `register` attribute was set to `true`. But it should be possible to update a collection without registering it.