### PR TITLE
♻️ Made StatusPubliser not-readonly

### DIFF
--- a/app/Statuses/StatusPublisher.php
+++ b/app/Statuses/StatusPublisher.php
@@ -10,11 +10,11 @@ use MyParcelCom\Microservice\Shipments\Shipment;
 use function array_map;
 use function env;
 
-readonly class StatusPublisher
+class StatusPublisher
 {
     public function __construct(
-        private SnsClient $snsClient,
-        private TransformerService $transformerService
+        readonly private SnsClient $snsClient,
+        readonly private TransformerService $transformerService
     ) {
     }
 


### PR DESCRIPTION
# Changes
Read-only classes cannot be:
- extended
- mocked (implied)

This imposes a high risk with declaring `StatusPublisher` as a read-only class because we would mock the class regularly in unit tests so we can override the publish method. 