### PR TITLE
🔧 Remove hardcoded app name from sns test

### DIFF
--- a/app/Statuses/StatusPublisher.php
+++ b/app/Statuses/StatusPublisher.php
@@ -37,7 +37,7 @@ readonly class StatusPublisher
     {
         return array_map(function (Status $status) {
             return [
-                'MessageGroupId' => env('APP_NAME'),
+                'MessageGroupId' => config('app.name'),
                 'Message'        => [
                     'shipment_id' => $status->shipment()->first()->getId(),
                     'status'        => $this->transformerService->transformResource($status),

--- a/tests/Feature/StatusPublisherTest.php
+++ b/tests/Feature/StatusPublisherTest.php
@@ -54,7 +54,7 @@ class StatusPublisherTest extends TestCase
             ->once()
             ->with([
                 [
-                    'MessageGroupId' => 'MyParcel.com Microservice',
+                    'MessageGroupId' => config('app.name'),
                     'Message'        => [
                         'shipment_id'   => 'shipment-id',
                         'status'        => [


### PR DESCRIPTION
Fix to properly test microservices that have a different app name and avoid:
```
1) MyParcelCom\Microservice\Tests\Feature\StatusPublisherTest::itShouldTransformAStatusMessage
Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_4_Aws_Sns_SnsClient::publishBatchAsync([0 => [...]]). Either the method was unexpected or its arguments matched no expected argument list for this method
```
