### PR TITLE
♻️ Allow overdiding the form request default rules

### DIFF
--- a/app/Http/FormRequest.php
+++ b/app/Http/FormRequest.php
@@ -118,7 +118,7 @@ class FormRequest extends BaseFormRequest
         $this->getInputSource()->replace($this->all());
     }
 
-    private function defaultRules(): array
+    protected function defaultRules(): array
     {
         return [];
     }

--- a/mp.sh
+++ b/mp.sh
@@ -44,7 +44,7 @@ if [ ! -f ${ROOT_DIR}/.env ]; then
 fi
 IFS=$'\n' && export $(grep -v '^#' ${ROOT_DIR}/.env | xargs -0) && unset IFS
 
-COMPOSE="docker-compose"
+COMPOSE="docker compose --compatibility"
 
 if [ $# -gt 0 ]; then
   createMicronet

--- a/mp.sh
+++ b/mp.sh
@@ -44,7 +44,7 @@ if [ ! -f ${ROOT_DIR}/.env ]; then
 fi
 IFS=$'\n' && export $(grep -v '^#' ${ROOT_DIR}/.env | xargs -0) && unset IFS
 
-COMPOSE="docker compose --compatibility"
+COMPOSE="docker-compose"
 
 if [ $# -gt 0 ]; then
   createMicronet


### PR DESCRIPTION
# Changes
The defaultRules function is now unsable because it is private, cannot be extended in particular use cases (like for multi-colli request)