### PR TITLE
✨ Identify shipments by tracking code and mp shipment ID

### DIFF
--- a/app/Statuses/Publish/StatusMessage.php
+++ b/app/Statuses/Publish/StatusMessage.php
@@ -11,25 +11,29 @@ class StatusMessage
 {
     public function __construct(
         public readonly string $id,
-        public readonly string $shipmentId,
         public readonly PostponePoll $postponePoll,
         public readonly Status $status,
+        public readonly ?string $shipmentId = null,
+        public readonly ?string $trackingCode = null,
+        public readonly ?string $myParcelComShipmentId = null,
         public readonly ?string $origin = null,
     ) {
     }
 
     public function serialize(TransformerService $transformerService): array
     {
-        $message = [
-            'origin'        => $this->origin ?? config('app.name'),
-            'shipment_id'   => $this->shipmentId,
-            'status'        => $transformerService->transformResource($this->status),
-            'postpone_poll' => $this->postponePoll->serialize(),
-        ];
+        $message = array_filter([
+            'origin'                  => $this->origin ?? config('app.name'),
+            'shipment_id'             => $this->shipmentId,
+            'tracking_code'           => $this->trackingCode,
+            'myparcelcom_shipment_id' => $this->myParcelComShipmentId,
+            'status'                  => $transformerService->transformResource($this->status),
+            'postpone_poll'           => $this->postponePoll->serialize(),
+        ]);
 
         return [
-            'Id'             => $this->id,
-            'Message'        => json_encode($message, JSON_THROW_ON_ERROR),
+            'Id'      => $this->id,
+            'Message' => json_encode($message, JSON_THROW_ON_ERROR),
         ];
     }
 }

--- a/tests/Unit/Statuses/Publish/PublisherTest.php
+++ b/tests/Unit/Statuses/Publish/PublisherTest.php
@@ -13,7 +13,7 @@ use MyParcelCom\Microservice\Statuses\Publish\PostponePoll;
 use MyParcelCom\Microservice\Statuses\Publish\Publisher;
 use MyParcelCom\Microservice\Statuses\Publish\StatusMessage;
 use MyParcelCom\Microservice\Statuses\Status;
-use PHPUnit\Framework\TestCase;
+use MyParcelCom\Microservice\Tests\TestCase;
 
 class PublisherTest extends TestCase
 {
@@ -23,8 +23,7 @@ class PublisherTest extends TestCase
     {
         $snsClient = Mockery::mock(SnsClient::class);
         $snsClient
-            ->shouldReceive('publishBatchAsync')
-            ->once()
+            ->expects('publishBatchAsync')
             ->with([
                 'PublishBatchRequestEntries' => [
                     [
@@ -35,14 +34,13 @@ class PublisherTest extends TestCase
                 ],
                 'TopicArn'                   => 'test',
             ])
-            ->andReturn(Mockery::mock(Promise::class));
+            ->andReturns(Mockery::mock(Promise::class));
 
         $transformerService = Mockery::mock(TransformerService::class);
         $transformerService
-            ->shouldReceive('transformResource')
-            ->once()
+            ->expects('transformResource')
             ->with(Mockery::type(Status::class))
-            ->andReturn([
+            ->andReturns([
                 'data' => [
                     'type'       => 'statuses',
                     'attributes' => [
@@ -56,11 +54,11 @@ class PublisherTest extends TestCase
         $publisher->publish(
             'test',
             new StatusMessage(
-                'test',
-                'test',
-                Mockery::mock(PostponePoll::class, ['serialize' => 'PT1H2M3S']),
-                Mockery::mock(Status::class),
-                'test-origin',
+                id: 'test',
+                postponePoll: Mockery::mock(PostponePoll::class, ['serialize' => 'PT1H2M3S']),
+                status: Mockery::mock(Status::class),
+                shipmentId: 'test',
+                origin: 'test-origin',
             )
         );
     }

--- a/tests/Unit/Statuses/Publish/StatusMessageTest.php
+++ b/tests/Unit/Statuses/Publish/StatusMessageTest.php
@@ -23,11 +23,11 @@ class StatusMessageTest extends TestCase
         $shipmentId = Uuid::uuid4()->toString();
 
         $statusesMessage = new StatusMessage(
-            $id,
-            $shipmentId,
-            Mockery::mock(PostponePoll::class, ['serialize' => 'PT1H2M3S']),
-            Mockery::mock(Status::class),
-            'test-origin',
+            id: $id,
+            postponePoll: Mockery::mock(PostponePoll::class, ['serialize' => 'PT1H2M3S']),
+            status: Mockery::mock(Status::class),
+            shipmentId: $shipmentId,
+            origin: 'test-origin',
         );
 
         $transformerService = Mockery::mock(TransformerService::class);
@@ -45,9 +45,9 @@ class StatusMessageTest extends TestCase
             ]);
 
         $expected = [
-            'Id'             => $id,
+            'Id'      => $id,
             // message is json encoded string
-            'Message'        => "{\"origin\":\"test-origin\",\"shipment_id\":\"{$shipmentId}\",\"status\":{\"data\":{\"type\":\"statuses\",\"attributes\":{\"code\":\"test\"}}},\"postpone_poll\":\"PT1H2M3S\"}",
+            'Message' => "{\"origin\":\"test-origin\",\"shipment_id\":\"{$shipmentId}\",\"status\":{\"data\":{\"type\":\"statuses\",\"attributes\":{\"code\":\"test\"}}},\"postpone_poll\":\"PT1H2M3S\"}",
         ];
 
         self::assertEquals($expected, $statusesMessage->serialize($transformerService));


### PR DESCRIPTION
# Changes
Aside from shipment ID (vendor ID in the API), we can now identify a shipment by the tracking code or the myparcelcom shipment ID (whichever available)