### PR TITLE
🦺 Add sanitization to use a fallback value for a field when its rule would have failed

### DIFF
--- a/app/Rules/Sanitization/FallbackValueSanitization.php
+++ b/app/Rules/Sanitization/FallbackValueSanitization.php
@@ -7,8 +7,13 @@ namespace MyParcelCom\Microservice\Rules\Sanitization;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
-class NullifyIfInvalidSanitization extends BaseSanitization
+class FallbackValueSanitization extends BaseSanitization
 {
+    public function __construct(
+        private readonly mixed $defaultValue,
+    ) {
+    }
+
     public function sanitize(
         string $key,
         array $parameters,
@@ -34,9 +39,9 @@ class NullifyIfInvalidSanitization extends BaseSanitization
                     Arr::only($shipmentRules, $key)
                 );
 
-                // Nullify value if validation fails
+                // Fallback to default value if validation fails
                 if ($validator->fails()) {
-                    Arr::set($parameters, $singleKey, null);
+                    Arr::set($parameters, $singleKey, $this->defaultValue);
                 }
             }
         }

--- a/app/Rules/Sanitization/NullifyIfInvalidSanitization.php
+++ b/app/Rules/Sanitization/NullifyIfInvalidSanitization.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Microservice\Rules\Sanitization;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+class NullifyIfInvalidSanitization extends BaseSanitization
+{
+    public function sanitize(
+        string $key,
+        array $parameters,
+        array $shipmentRules = []
+    ): array {
+        $values = data_get($parameters, $key);
+        if ($values) {
+            if (!is_array($values)) {
+                $values = [$values];
+            }
+            $keyedValues = collect($this->getKeys($key, $parameters))->combine($values)->toArray();
+            foreach ($keyedValues as $singleKey => $singleValue) {
+                // Prevent sanitization for optional empty fields
+                if (empty($singleValue) && $this->isParameterOptional($singleKey, $key, $parameters, $shipmentRules)) {
+                    continue;
+                }
+
+                // Perform original validation on single value
+                $data = [];
+                Arr::set($data, $singleKey, $singleValue);
+                $validator = Validator::make(
+                    $data,
+                    Arr::only($shipmentRules, $key)
+                );
+
+                // Nullify value if validation fails
+                if ($validator->fails()) {
+                    Arr::set($parameters, $singleKey, null);
+                }
+            }
+        }
+        return $parameters;
+    }
+}


### PR DESCRIPTION
When working on InPost microservice, I noticed that a specific regex was required for the phone number field, but the field was not necessarily required to create a successful request to the API. So with validation disabled (and sanitization running) I added a rule that will nullify a field when its rule fails.