### PR TITLE
:sparkles: add GET PUDO by ID endpoint

### DIFF
--- a/app/PickUpDropOffLocations/PickUpDropOffLocationController.php
+++ b/app/PickUpDropOffLocations/PickUpDropOffLocationController.php
@@ -75,7 +75,7 @@ class PickUpDropOffLocationController extends Controller
         string $pickUpDropOffLocationId,
     ): JsonResponse|Response {
         $location = $pickUpDropOffLocationRepository->getById($pickUpDropOffLocationId);
-        if ($location) {
+        if (isset($location)) {
             return new JsonResponse($transformerService->transformResource($location));
         }
 

--- a/app/PickUpDropOffLocations/PickUpDropOffLocationController.php
+++ b/app/PickUpDropOffLocations/PickUpDropOffLocationController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace MyParcelCom\Microservice\PickUpDropOffLocations;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use MyParcelCom\JsonApi\Transformers\TransformerService;
 use MyParcelCom\Microservice\Http\Controllers\Controller;
 use MyParcelCom\Microservice\Http\Request;
+use MyParcelCom\Microservice\PickUpDropOffLocations\PickUpDropOffLocationRepository;
 
 class PickUpDropOffLocationController extends Controller
 {
@@ -17,7 +19,7 @@ class PickUpDropOffLocationController extends Controller
         TransformerService $transformerService,
         Request $request,
         string $countryCode,
-        string $postalCode
+        string $postalCode,
     ): JsonResponse {
         $filters = $request->getFilter();
         $categories = array_filter(explode(',', Arr::get($filters, 'categories', '')));
@@ -32,7 +34,7 @@ class PickUpDropOffLocationController extends Controller
             $request->query('city'),
             $categories,
             $features,
-            $locationType
+            $locationType,
         );
 
         $response = $transformerService->transformResources($pudoLocations);
@@ -45,7 +47,7 @@ class PickUpDropOffLocationController extends Controller
         TransformerService $transformerService,
         Request $request,
         string $latitude,
-        string $longitude
+        string $longitude,
     ): JsonResponse {
         $filters = $request->getFilter();
         $categories = array_filter(explode(',', Arr::get($filters, 'categories', '')));
@@ -59,11 +61,24 @@ class PickUpDropOffLocationController extends Controller
             $radius,
             $categories,
             $features,
-            $locationType
+            $locationType,
         );
 
         $response = $transformerService->transformResources($pudoLocations);
 
         return new JsonResponse($response);
+    }
+
+    public function getOne(
+        PickUpDropOffLocationRepository $pickUpDropOffLocationRepository,
+        TransformerService $transformerService,
+        string $pickUpDropOffLocationId,
+    ): JsonResponse|Response {
+        $location = $pickUpDropOffLocationRepository->getById($pickUpDropOffLocationId);
+        if ($location->count()) {
+            return new JsonResponse($transformerService->transformResources($location));
+        }
+
+        return new Response('', Response::HTTP_NOT_FOUND);
     }
 }

--- a/app/PickUpDropOffLocations/PickUpDropOffLocationController.php
+++ b/app/PickUpDropOffLocations/PickUpDropOffLocationController.php
@@ -75,8 +75,8 @@ class PickUpDropOffLocationController extends Controller
         string $pickUpDropOffLocationId,
     ): JsonResponse|Response {
         $location = $pickUpDropOffLocationRepository->getById($pickUpDropOffLocationId);
-        if ($location->count()) {
-            return new JsonResponse($transformerService->transformResources($location));
+        if ($location) {
+            return new JsonResponse($transformerService->transformResource($location));
         }
 
         return new Response('', Response::HTTP_NOT_FOUND);

--- a/app/PickUpDropOffLocations/PickUpDropOffLocationRepository.php
+++ b/app/PickUpDropOffLocations/PickUpDropOffLocationRepository.php
@@ -8,6 +8,7 @@ use DateInterval;
 use Illuminate\Support\Collection;
 use MyParcelCom\JsonApi\Resources\CollectionResources;
 use MyParcelCom\JsonApi\Resources\Interfaces\ResourcesInterface;
+use MyParcelCom\JsonApi\Resources\PromiseResources;
 use MyParcelCom\Microservice\Carrier\CarrierApiGatewayInterface;
 use Psr\SimpleCache\CacheInterface;
 
@@ -77,6 +78,15 @@ class PickUpDropOffLocationRepository
         // TODO: Map data to PickUpDropOffLocation objects.
         // TODO: Put PickUpDropOffLocation objects in an object that implements ResourcesInterface.
         // TODO: Return pudo points filtered by passed categories using the method `filterLocationsByCategories()`
+    }
+
+    public function getById(string $pickUpDropOffLocationId): ResourcesInterface
+    {
+        // TODO: Get the pudo point from carrier (use CarrierApiGateway).
+        // TODO: Map data to PickUpDropOffLocation object.
+        // TODO: Return PickUpDropOffLocation object in an object that implements ResourcesInterface.
+
+        return new CollectionResources(new Collection());
     }
 
     protected function setCachedLocations(

--- a/app/PickUpDropOffLocations/PickUpDropOffLocationRepository.php
+++ b/app/PickUpDropOffLocations/PickUpDropOffLocationRepository.php
@@ -80,13 +80,13 @@ class PickUpDropOffLocationRepository
         // TODO: Return pudo points filtered by passed categories using the method `filterLocationsByCategories()`
     }
 
-    public function getById(string $pickUpDropOffLocationId): ResourcesInterface
+    public function getById(string $pickUpDropOffLocationId): ?PickUpDropOffLocation
     {
         // TODO: Get the pudo point from carrier (use CarrierApiGateway).
         // TODO: Map data to PickUpDropOffLocation object.
         // TODO: Return PickUpDropOffLocation object in an object that implements ResourcesInterface.
 
-        return new CollectionResources(new Collection());
+        return null;
     }
 
     protected function setCachedLocations(

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,10 @@ Route::get('/pickup-dropoff-locations/{latitude}/{longitude}', [PickUpDropOffLoc
 Route::get('/pickup-dropoff-locations/{countryCode}/{postalCode}', [PickUpDropOffLocationController::class, 'getAllByCountryAndPostalCode'])
     ->name('get-pickup-dropoff-locations-by-country-and-postal-code');
 
+//Route::get(
+//    '/pickup-dropoff-locations/{pudo_id}', [PickUpDropOffLocationController::class, 'getOne'])
+//    ->name('get-pickup-dropoff-locations-by-id');
+
 Route::get('/shipments/{shipmentId}/statuses/{trackingCode}', [StatusController::class, 'getStatuses'])
     ->name('get-statuses');
 

--- a/tests/Endpoints/PickUpDropOffLocationsTest.php
+++ b/tests/Endpoints/PickUpDropOffLocationsTest.php
@@ -33,23 +33,23 @@ class PickUpDropOffLocationsTest extends TestCase
         $this->assertJsonSchema(
             '/pickup-dropoff-locations/{country_code}/{postal_code}',
             '/pickup-dropoff-locations/GB/B694DA',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/GB/B694DA',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
 
         $this->assertJsonSchema(
             '/pickup-dropoff-locations/{latitude}/{longitude}',
             '/pickup-dropoff-locations/52.359686/4.884573',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/52.359686/4.884573',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
     }
 
@@ -61,12 +61,12 @@ class PickUpDropOffLocationsTest extends TestCase
         $response = $this->assertJsonSchema(
             '/pickup-dropoff-locations/{country_code}/{postal_code}',
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[categories]=pick-up',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[categories]=pick-up',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $locations = $response->json('data');
         array_walk($locations, function ($pudoPoint) {
@@ -78,12 +78,12 @@ class PickUpDropOffLocationsTest extends TestCase
         $response = $this->assertJsonSchema(
             '/pickup-dropoff-locations/{latitude}/{longitude}',
             '/pickup-dropoff-locations/52.359686/4.884573?filter[categories]=pick-up',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/52.359686/4.884573?filter[categories]=pick-up',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $locations = $response->json('data');
         array_walk($locations, function ($pudoPoint) {
@@ -99,12 +99,12 @@ class PickUpDropOffLocationsTest extends TestCase
         $response = $this->assertJsonSchema(
             '/pickup-dropoff-locations/{country_code}/{postal_code}',
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[categories]=drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[categories]=drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $locations = $response->json('data');
         array_walk($locations, function ($pudoPoint) {
@@ -116,12 +116,12 @@ class PickUpDropOffLocationsTest extends TestCase
         $response = $this->assertJsonSchema(
             '/pickup-dropoff-locations/{latitude}/{longitude}',
             '/pickup-dropoff-locations/52.359686/4.884573?filter[categories]=drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/52.359686/4.884573?filter[categories]=drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $locations = $response->json('data');
         array_walk($locations, function ($pudoPoint) {
@@ -137,12 +137,12 @@ class PickUpDropOffLocationsTest extends TestCase
         $response = $this->assertJsonSchema(
             '/pickup-dropoff-locations/{country_code}/{postal_code}',
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[categories]=pick-up,drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[categories]=pick-up,drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $locations = $response->json('data');
         array_walk($locations, function ($pudoPoint) {
@@ -155,12 +155,12 @@ class PickUpDropOffLocationsTest extends TestCase
         $response = $this->assertJsonSchema(
             '/pickup-dropoff-locations/{latitude}/{longitude}',
             '/pickup-dropoff-locations/52.359686/4.884573?filter[categories]=pick-up,drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $this->assertJsonDataCount(
             2, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/52.359686/4.884573?filter[categories]=pick-up,drop-off',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
         $locations = $response->json('data');
         array_walk($locations, function ($pudoPoint) {
@@ -175,25 +175,54 @@ class PickUpDropOffLocationsTest extends TestCase
         $this->assertJsonSchema(
             '/pickup-dropoff-locations/{latitude}/{longitude}',
             '/pickup-dropoff-locations/52.359686/4.884573?filter[features]=print-label-in-store',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
 
         $this->assertJsonDataCount(
             10, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/52.359686/4.884573?filter[features]=print-label-in-store',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
 
         $this->assertJsonSchema(
             '/pickup-dropoff-locations/{country_code}/{postal_code}',
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[features]=print-label-in-store',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
 
         $this->assertJsonDataCount(
             10, // TODO: Update this according to the used stub.
             '/pickup-dropoff-locations/GB/EC1A 1BB?filter[features]=print-label-in-store',
-            $this->getRequestHeaders()
+            $this->getRequestHeaders(),
         );
+    }
+
+    /** @test */
+    public function itRetrievesAPickUpAndDropOffLocationById()
+    {
+        $this->markTestSkipped();
+
+        $pudoLocationId = 'pudo-location-id'; // TODO: Update this according to the used stub.
+        $this->assertJsonSchema(
+            "/pickup-dropoff-locations/{pudo_id}",
+            "/pickup-dropoff-locations/$pudoLocationId",
+            $this->getRequestHeaders(),
+        );
+
+        $this->assertJsonDataCount(
+            1,
+            "/pickup-dropoff-locations/$pudoLocationId",
+            $this->getRequestHeaders(),
+        );
+    }
+
+    /** @test */
+    public function itReturns404IfNoPudoLocationsAreFound()
+    {
+        $this->markTestSkipped();
+
+        $pudoLocationId = 'non-existent-pudo-location-id';
+        $this->get("/pickup-dropoff-locations/$pudoLocationId", $this->getRequestHeaders())
+            ->assertNotFound();
     }
 }

--- a/tests/Unit/PickUpDropOffLocations/PickUpDropOffLocationRepositoryTest.php
+++ b/tests/Unit/PickUpDropOffLocations/PickUpDropOffLocationRepositoryTest.php
@@ -41,4 +41,14 @@ class PickUpDropOffLocationRepositoryTest extends TestCase
 
         $this->assertInstanceOf(ResourcesInterface::class, $resources);
     }
+
+    /** @test */
+    public function testGetById()
+    {
+        $this->markTestSkipped();
+
+        $resources = $this->pickUpDropOffLocationRepository->getById('pudo-location-id');
+
+        $this->assertInstanceOf(ResourcesInterface::class, $resources);
+    }
 }

--- a/tests/Unit/PickUpDropOffLocations/PickUpDropOffLocationRepositoryTest.php
+++ b/tests/Unit/PickUpDropOffLocations/PickUpDropOffLocationRepositoryTest.php
@@ -7,6 +7,7 @@ namespace MyParcelCom\Microservice\Tests\Unit\PickUpDropOffLocations;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use MyParcelCom\JsonApi\Resources\Interfaces\ResourcesInterface;
+use MyParcelCom\Microservice\PickUpDropOffLocations\PickUpDropOffLocation;
 use MyParcelCom\Microservice\PickUpDropOffLocations\PickUpDropOffLocationRepository;
 use MyParcelCom\Microservice\Tests\Mocks\CarrierApiGatewayMock;
 use PHPUnit\Framework\TestCase;
@@ -43,12 +44,22 @@ class PickUpDropOffLocationRepositoryTest extends TestCase
     }
 
     /** @test */
-    public function testGetById()
+    public function testGetByIdReturnsModel()
     {
         $this->markTestSkipped();
 
-        $resources = $this->pickUpDropOffLocationRepository->getById('pudo-location-id');
+        $pudoLocation = $this->pickUpDropOffLocationRepository->getById('pudo-location-id');
 
-        $this->assertInstanceOf(ResourcesInterface::class, $resources);
+        $this->assertInstanceOf(PickUpDropOffLocation::class, $pudoLocation);
+    }
+
+    /** @test */
+    public function testGetByIdReturnsNull()
+    {
+        $this->markTestSkipped();
+
+        $pudoLocation = $this->pickUpDropOffLocationRepository->getById('pudo-location-id');
+
+        $this->assertNull($pudoLocation);
     }
 }


### PR DESCRIPTION
## Changes
- add `GET /pickup-dropoff-locations/{pudo_id}` endpoint
- add method `getById` to PickUpDropOffLocationRepository
- add tests (mark as skipped)

## Related Jira issue
https://myparcelcombv.atlassian.net/browse/MP-5579