### PR TITLE
:ok_hand: QA: Enable the get PUDO by ID route always

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -36,9 +36,9 @@ Route::get('/pickup-dropoff-locations/{latitude}/{longitude}', [PickUpDropOffLoc
 Route::get('/pickup-dropoff-locations/{countryCode}/{postalCode}', [PickUpDropOffLocationController::class, 'getAllByCountryAndPostalCode'])
     ->name('get-pickup-dropoff-locations-by-country-and-postal-code');
 
-//Route::get(
-//    '/pickup-dropoff-locations/{pudo_id}', [PickUpDropOffLocationController::class, 'getOne'])
-//    ->name('get-pickup-dropoff-locations-by-id');
+Route::get(
+    '/pickup-dropoff-locations/{pudo_id}', [PickUpDropOffLocationController::class, 'getOne'])
+    ->name('get-pickup-dropoff-locations-by-id');
 
 Route::get('/shipments/{shipmentId}/statuses/{trackingCode}', [StatusController::class, 'getStatuses'])
     ->name('get-statuses');


### PR DESCRIPTION
# Changes
The route for getting a PUDO by ID can be uncommented because the access to this feature is already controller by the API through a flag boolean field in the `carriers` table. Thus there is no need to have it not routed everywhere.