### PR TITLE
✨ Service rates can have options with a price

### DIFF
--- a/app/ServiceRates/Option.php
+++ b/app/ServiceRates/Option.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Microservice\ServiceRates;
+
+use MyParcelCom\Microservice\Shipments\Option as ShipmentOption;
+
+class Option extends ShipmentOption
+{
+    private ?Price $price = null;
+
+    public static function fromShipmentOption(ShipmentOption $shipmentOption): self
+    {
+        return (new self())
+            ->setName($shipmentOption->getName())
+            ->setCode($shipmentOption->getCode())
+            ->setValues($shipmentOption->getValues());
+    }
+
+    public function getPrice(): ?Price
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?Price $price): self
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+}

--- a/app/ServiceRates/ServiceRate.php
+++ b/app/ServiceRates/ServiceRate.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Microservice\ServiceRates;
 
-use MyParcelCom\Microservice\Shipments\Option;
-
 class ServiceRate
 {
     private ?string $code = null;

--- a/app/ServiceRates/ServiceRate.php
+++ b/app/ServiceRates/ServiceRate.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Microservice\ServiceRates;
 
+use MyParcelCom\Microservice\Shipments\Option;
+
 class ServiceRate
 {
     private ?string $code = null;
@@ -16,6 +18,8 @@ class ServiceRate
     private ?Price $fuelSurcharge = null;
     private ?int $transitTimeMin = null;
     private ?int $transitTimeMax = null;
+    /** @var Option[] */
+    protected array $options = [];
 
     public function __construct(
         private Price $price,
@@ -151,5 +155,24 @@ class ServiceRate
     public function getTransitTimeMax(): ?int
     {
         return $this->transitTimeMax;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function addOption(Option $option): self
+    {
+        $this->options[] = $option;
+
+        return $this;
+    }
+
+    public function setOptions(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
     }
 }

--- a/app/ServiceRates/ServiceRateTransformer.php
+++ b/app/ServiceRates/ServiceRateTransformer.php
@@ -6,6 +6,7 @@ namespace MyParcelCom\Microservice\ServiceRates;
 
 use MyParcelCom\JsonApi\Exceptions\ModelTypeException;
 use MyParcelCom\JsonApi\Transformers\AbstractTransformer;
+use MyParcelCom\Microservice\Shipments\Option;
 
 class ServiceRateTransformer extends AbstractTransformer
 {
@@ -51,10 +52,21 @@ class ServiceRateTransformer extends AbstractTransformer
                 'amount'   => $serviceRate->getFuelSurcharge()->getAmount(),
                 'currency' => $serviceRate->getFuelSurcharge()->getCurrency(),
             ]),
-            'transit_time' => array_filter([
+            'transit_time'   => array_filter([
                 'min' => $serviceRate->getTransitTimeMin(),
                 'max' => $serviceRate->getTransitTimeMax(),
             ]),
+            'options'        => array_map(function (Option $option) {
+                return array_filter([
+                    'code'   => $option->getCode(),
+                    'name'   => $option->getName(),
+                    'values' => $option->getValues() === null ? null : array_filter($option->getValues()),
+                    'price'  => $option->getPrice() === null ? null : array_filter([
+                        'amount'   => $option->getPrice()->getAmount(),
+                        'currency' => $option->getPrice()->getCurrency(),
+                    ]),
+                ]);
+            }, $serviceRate->getOptions()),
         ]);
     }
 

--- a/app/ServiceRates/ServiceRateTransformer.php
+++ b/app/ServiceRates/ServiceRateTransformer.php
@@ -6,7 +6,6 @@ namespace MyParcelCom\Microservice\ServiceRates;
 
 use MyParcelCom\JsonApi\Exceptions\ModelTypeException;
 use MyParcelCom\JsonApi\Transformers\AbstractTransformer;
-use MyParcelCom\Microservice\Shipments\Option;
 
 class ServiceRateTransformer extends AbstractTransformer
 {

--- a/app/Shipments/Option.php
+++ b/app/Shipments/Option.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Microservice\Shipments;
 
-use MyParcelCom\Microservice\ServiceRates\Price;
-
 class Option
 {
     private string $code;
     private ?string $name = null;
     private ?array $values = null;
-    private ?Price $price = null;
 
     public function getCode(): string
     {
@@ -45,18 +42,6 @@ class Option
     public function setValues(?array $values): self
     {
         $this->values = $values;
-
-        return $this;
-    }
-
-    public function getPrice(): ?Price
-    {
-        return $this->price;
-    }
-
-    public function setPrice(?Price $price): self
-    {
-        $this->price = $price;
 
         return $this;
     }

--- a/app/Shipments/Option.php
+++ b/app/Shipments/Option.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Microservice\Shipments;
 
+use MyParcelCom\Microservice\ServiceRates\Price;
+
 class Option
 {
     private string $code;
     private ?string $name = null;
     private ?array $values = null;
+    private ?Price $price = null;
 
     public function getCode(): string
     {
@@ -42,6 +45,18 @@ class Option
     public function setValues(?array $values): self
     {
         $this->values = $values;
+
+        return $this;
+    }
+
+    public function getPrice(): ?Price
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?Price $price): self
+    {
+        $this->price = $price;
 
         return $this;
     }

--- a/tests/Unit/ServiceRates/ServiceRateTransformerTest.php
+++ b/tests/Unit/ServiceRates/ServiceRateTransformerTest.php
@@ -8,10 +8,10 @@ use Illuminate\Routing\UrlGenerator;
 use Mockery;
 use MyParcelCom\JsonApi\Exceptions\ModelTypeException;
 use MyParcelCom\JsonApi\Transformers\TransformerFactory;
+use MyParcelCom\Microservice\ServiceRates\Option;
 use MyParcelCom\Microservice\ServiceRates\Price;
 use MyParcelCom\Microservice\ServiceRates\ServiceRate;
 use MyParcelCom\Microservice\ServiceRates\ServiceRateTransformer;
-use MyParcelCom\Microservice\Shipments\Option;
 use MyParcelCom\Microservice\Tests\TestCase;
 use stdClass;
 

--- a/tests/Unit/ServiceRates/ServiceRateTransformerTest.php
+++ b/tests/Unit/ServiceRates/ServiceRateTransformerTest.php
@@ -11,6 +11,7 @@ use MyParcelCom\JsonApi\Transformers\TransformerFactory;
 use MyParcelCom\Microservice\ServiceRates\Price;
 use MyParcelCom\Microservice\ServiceRates\ServiceRate;
 use MyParcelCom\Microservice\ServiceRates\ServiceRateTransformer;
+use MyParcelCom\Microservice\Shipments\Option;
 use MyParcelCom\Microservice\Tests\TestCase;
 use stdClass;
 
@@ -41,6 +42,14 @@ class ServiceRateTransformerTest extends TestCase
             'getFuelSurcharge'  => Mockery::mock(Price::class, ['getAmount' => 15, 'getCurrency' => 'GBP']),
             'getTransitTimeMin' => 2,
             'getTransitTimeMax' => 4,
+            'getOptions'        => [
+                Mockery::mock(Option::class, [
+                    'getCode'   => 'some code',
+                    'getName'   => 'some name',
+                    'getValues' => null,
+                    'getPrice'  => Mockery::mock(Price::class, ['getAmount' => 5, 'getCurrency' => 'GBP']),
+                ]),
+            ],
         ]);
     }
 
@@ -59,6 +68,13 @@ class ServiceRateTransformerTest extends TestCase
             'purchase_price' => ['amount' => 75, 'currency' => 'GBP'],
             'fuel_surcharge' => ['amount' => 15, 'currency' => 'GBP'],
             'transit_time'   => ['min' => 2, 'max' => 4],
+            'options'        => [
+                [
+                    'code'  => 'some code',
+                    'name'  => 'some name',
+                    'price' => ['amount' => 5, 'currency' => 'GBP'],
+                ],
+            ],
         ], $this->transformer->getAttributes($this->serviceRate));
     }
 


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-6848
---
The service-rates response from our microservices currently consists of:
- `price` populated with the carrier's price, minus the fuel surcharge
- `fuel_surcharge`

We want them to be able to consist of:
- `price` populated with the carrier's price, minus the fuel surcharge, minus the option price(s)
- `fuel_surcharge`
- `options` which could have their own `price` (basically a copy of the options array from the received shipment data)